### PR TITLE
add headers file for redirect security

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,5 @@
+/*
+  Content-Security-Policy: object-src 'none'; frame-ancestors 'none'
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  Strict-Transport-Security: max-age=63072000


### PR DESCRIPTION
Per [this Asana task](https://app.asana.com/0/1200099998847559/1202727990594956/f), added a basic headers file to get rid of some Security Scorecard errors stemming from our legacy sites that only serve redirects.

Resolves [SECENG-89](https://dbtlabs.atlassian.net/browse/SECENG-89)